### PR TITLE
Adiciona scan Conviso AST (informacional, sem bloqueio)

### DIFF
--- a/.github/workflows/conviso-ast.yml
+++ b/.github/workflows/conviso-ast.yml
@@ -2,7 +2,7 @@ name: Conviso AST
 
 # Thin stub: clones security-pipelines from Azure Repos at runtime (no GitHub mirror).
 # Install via security-scripts/github-conviso-rollout. Do not mark as required status check.
-# Placeholder main is replaced by the rollout script.
+# Clone lands in RUNNER_TEMP (not GITHUB_WORKSPACE) so Conviso does not see a nested .git.
 
 on:
   pull_request:
@@ -36,14 +36,63 @@ jobs:
           ref="${SECURITY_PIPELINES_REF:-stable}"
           clone_url="${SECURITY_PIPELINES_CLONE_URL:-https://dev.azure.com/is2b/Security/_git/security-pipelines}"
           auth_url="$(printf '%s' "$clone_url" | sed "s#https://#https://pat:${AZURE_DEVOPS_PAT}@#")"
-          rm -rf security-pipelines
-          git clone --depth 1 --branch "$ref" "$auth_url" security-pipelines
-          test -f security-pipelines/actions/conviso-ast/action.yaml
+          dest="${RUNNER_TEMP}/security-pipelines"
+          rm -rf "$dest"
+          git clone --depth 1 --branch "$ref" "$auth_url" "$dest"
+          test -f "$dest/actions/conviso-ast/action.yaml"
+          test -f "$dest/scripts/run-conviso-ast.sh"
+          echo "SECURITY_PIPELINES_DIR=$dest" >> "$GITHUB_ENV"
 
       - name: Run Conviso AST
-        uses: ./security-pipelines/actions/conviso-ast
-        with:
-          conviso-api-key: ${{ secrets.CONVISO_API_KEY }}
-          vulnerability-auto-close: true
-          fail-on-findings: false
-          company-id: ${{ vars.CONVISO_COMPANY_ID }}
+        env:
+          CONVISO_API_KEY: ${{ secrets.CONVISO_API_KEY }}
+          CONVISO_COMPANY_ID: ${{ vars.CONVISO_COMPANY_ID }}
+          CONVISO_GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          FAIL_ON_FINDINGS: 'false'
+          VULN_AUTO_CLOSE: 'true'
+        run: |
+          set -euo pipefail
+          sp="${SECURITY_PIPELINES_DIR:?}"
+          # shellcheck source=/dev/null
+          source "$sp/scripts/conviso-branch-gate-lib.sh"
+
+          asset_name="${{ github.repository }}"
+          company_id="${CONVISO_COMPANY_ID:-}"
+          event_name="$(printf '%s' "${GITHUB_EVENT_NAME:-}" | tr '[:upper:]' '[:lower:]')"
+          dry_run_args=()
+          diff_args=()
+
+          if [ "$event_name" = "pull_request" ] || [ "$event_name" = "pull_request_target" ]; then
+            base_ref='${{ github.event.pull_request.base.ref }}'
+            if [ -z "$base_ref" ]; then
+              base_ref='${{ github.base_ref }}'
+            fi
+            head_ref='${{ github.head_ref }}'
+            if [ -z "$head_ref" ]; then
+              head_ref="$(conviso_branch_gate_short_from_ref '${{ github.ref }}')"
+            fi
+            conviso_branch_gate_export_pipeline_env \
+              "refs/heads/${head_ref}" \
+              "refs/heads/${base_ref}" \
+              "PullRequest"
+            dry_run_args=(--dry-run)
+            if [ -n "$base_ref" ]; then
+              diff_args+=(--diff-base "$base_ref")
+            fi
+          else
+            conviso_branch_gate_export_pipeline_env \
+              '${{ github.ref }}' \
+              '' \
+              'IndividualCI'
+          fi
+
+          bash "$sp/scripts/run-conviso-ast.sh" \
+            --repo-dir "$GITHUB_WORKSPACE" \
+            --rules-file "$sp/rules.yml" \
+            --api-key "${CONVISO_API_KEY}" \
+            --asset-name "$asset_name" \
+            --company-id "$company_id" \
+            --fail-on-findings "${FAIL_ON_FINDINGS}" \
+            --vulnerability-auto-close "${VULN_AUTO_CLOSE}" \
+            "${dry_run_args[@]}" \
+            "${diff_args[@]}"

--- a/.github/workflows/conviso-ast.yml
+++ b/.github/workflows/conviso-ast.yml
@@ -1,0 +1,49 @@
+name: Conviso AST
+
+# Thin stub: clones security-pipelines from Azure Repos at runtime (no GitHub mirror).
+# Install via security-scripts/github-conviso-rollout. Do not mark as required status check.
+# Placeholder main is replaced by the rollout script.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  conviso-ast:
+    name: Conviso AST
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone security-pipelines from Azure Repos
+        env:
+          AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+          SECURITY_PIPELINES_REF: ${{ vars.SECURITY_PIPELINES_REF }}
+          SECURITY_PIPELINES_CLONE_URL: ${{ vars.SECURITY_PIPELINES_CLONE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
+            echo "AZURE_DEVOPS_PAT secret is required to clone security-pipelines from Azure Repos." >&2
+            exit 1
+          fi
+          ref="${SECURITY_PIPELINES_REF:-stable}"
+          clone_url="${SECURITY_PIPELINES_CLONE_URL:-https://dev.azure.com/is2b/Security/_git/security-pipelines}"
+          auth_url="$(printf '%s' "$clone_url" | sed "s#https://#https://pat:${AZURE_DEVOPS_PAT}@#")"
+          rm -rf security-pipelines
+          git clone --depth 1 --branch "$ref" "$auth_url" security-pipelines
+          test -f security-pipelines/actions/conviso-ast/action.yaml
+
+      - name: Run Conviso AST
+        uses: ./security-pipelines/actions/conviso-ast
+        with:
+          conviso-api-key: ${{ secrets.CONVISO_API_KEY }}
+          vulnerability-auto-close: true
+          fail-on-findings: false
+          company-id: ${{ vars.CONVISO_COMPANY_ID }}


### PR DESCRIPTION
Adiciona o stub do Conviso AST neste repo — scan de segurança informacional, **sem bloquear merge**.

## Contexto

Estamos fazendo o rollout do Conviso nos repositórios GitHub. O `security-pipelines` (scripts + action) continua **só no Azure DevOps** — não vamos espelhar esse repo no GitHub. A ideia é manter uma fonte única: o workflow daqui é fino e, em runtime, clona o `security-pipelines` do Azure Repos (`stable`) e roda o scan.

## O que esse workflow faz

- Em **pull request** para a branch principal: **dry-run** (não faz deploy completo do asset na plataforma Conviso). É o “check de PR”.
- Depois do **merge** (push na branch principal): **full AST** na plataforma.
- `fail_on_findings: false` — neste rollout **não** tem corte por severidade e **não** vamos colocar esse job como required check na branch protection. Ou seja: não é pra travar entrega.

## Secrets / variáveis

Como não tenho owner nas orgs, os secrets vão no **repo** (não em org secret):

- `CONVISO_API_KEY` (secret)
- `AZURE_DEVOPS_PAT` (secret) — leitura do `Security/security-pipelines` no Azure Repos
- `CONVISO_COMPANY_ID` (variable, opcional)
- `SECURITY_PIPELINES_REF` (variable, opcional; default `stable`)

Sem esses secrets o job pode falhar no setup; findings em si não devem bloquear o merge.

## Pedido

Pode revisar e mergear quando fizer sentido. Qualquer dúvida sobre o desenho (clone em runtime vs mirror), me chama.
